### PR TITLE
fix: Error when rolling accentuated ability from the character sheet

### DIFF
--- a/module/actor/sheet/character-sheet.js
+++ b/module/actor/sheet/character-sheet.js
@@ -52,6 +52,7 @@ export class MBCharacterSheet extends MBActorSheet {
       const ability = data.system.abilities[abilityName];
       const translationKey = `MB.Ability${upperCaseFirst(abilityName)}`;
       ability.label = game.i18n.localize(translationKey);
+      ability.untranslatedLabel = abilityName;
       data.system.orderedAbilities.push(ability);
     }
     // custom abilities are in an ordered csv string

--- a/module/handlebars.js
+++ b/module/handlebars.js
@@ -35,8 +35,9 @@ export const configureHandlebars = () => {
     return result;
   });
   Handlebars.registerHelper("abilityLabelClass", function (string) {
-    string = string.label;
-    if (!["Agility", "Presence", "Strength", "Toughness"].includes(string)) {
+    string = string.untranslatedLabel;
+    console.error(string)
+    if (!["agility", "presence", "strength", "toughness"].includes(string)) {
       return "custom " + string.toLowerCase();
     }
     return string.toLowerCase();


### PR DESCRIPTION
When rolling ability from the character sheet, an accentuated name (like translated name) will raise an error with the Roll class. To prevent this, we use untranslated label instead. Moreover, this commit applies a correction on the non-custom abilities list.

Refs: https://github.com/fvtt-fria-ligan/morkborg-foundry-vtt/issues/174