### PR TITLE
Fix previous commit

### DIFF
--- a/system.json
+++ b/system.json
@@ -85,8 +85,10 @@
   ],
   "socket": true,
   "initiative": "1d6",
-  "grid.distance": 10,
-  "grid.units": "ft",
+  "grid":{
+    "distance": 10,
+    "units": "ft"
+  },
   "primaryTokenAttribute": "hp",
   "secondaryTokenAttribute": null,
   "url": "https://github.com/fvtt-fria-ligan/morkborg-foundry-vtt",


### PR DESCRIPTION
Tested, Foundry V.12 doesn't like when you use just "grid.distance" and "grid.units"