### PR TITLE
Fix ammo display and tracking

### DIFF
--- a/module/actor/attack.js
+++ b/module/actor/attack.js
@@ -238,7 +238,7 @@ async function decrementWeaponAmmo(actor, weapon) {
     const ammo = actor.items.get(weapon.system.ammoId);
     if (ammo) {
       const attr = "system.quantity";
-      const currQuantity = getProperty(ammo, attr);
+      const currQuantity = ammo.system.quantity;
       if (currQuantity > 1) {
         // decrement quantity by 1
         await ammo.update({ [attr]: currQuantity - 1 });

--- a/templates/actor/common/violence-tab.hbs
+++ b/templates/actor/common/violence-tab.hbs
@@ -42,7 +42,7 @@
                     <option value="">{{localize 'MB.ItemTypeAmmo'}}</option>
                     {{log "data" ../data.system.ammo "selected" item.system.ammoId}}
                     {{!-- TODO: display ammo quantity again --}}
-                    {{selectOptions ../data.system.ammo selected=item.system.ammoId nameAttr="_id" labelAttr="name"}}
+                    {{selectOptions ../data.system.ammo selected=item.system.ammoId valueAttr="_id" labelAttr="name"}}
                   </select>
                 </div>
               {{/if}} 


### PR DESCRIPTION
Fixes the display of ammo in the "Violence" tab to list all ammo types again after it was broken in https://github.com/fvtt-fria-ligan/morkborg-foundry-vtt/pull/207.

Additionally, fix an underlying bug that prevented ammo tracking from working with since https://github.com/fvtt-fria-ligan/morkborg-foundry-vtt/commit/1526c828c028b3057f5e1b10b064f8e051054ca3 (`getProperty` is undefined).